### PR TITLE
Adiciona terceira página do cadastro

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,16 +1,21 @@
 {
   "env": {
-    "browser": true,
-    "es2021": true
+      "browser": true,
+      "es2021": true
   },
-  "extends": ["plugin:react/recommended", "airbnb", "eslint:recommended"],
-  "overrides": [],
+  "extends": [
+      "plugin:react/recommended",
+      "airbnb",
+      "eslint:recommended"
+  ],
+  "overrides": [
+  ],
   "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": "latest",
-    "sourceType": "module"
+      "ecmaFeatures": {
+          "jsx": true
+      },
+      "ecmaVersion": "latest",
+      "sourceType": "module"
   },
   "settings": {
     "import/resolver": {
@@ -19,159 +24,161 @@
       }
     }
   },
-  "plugins": ["react"],
+  "plugins": [
+      "react"
+  ],
   "rules": {
-    "indent": ["error", 2],
-    "linebreak-style": 0,
-    "quotes": ["error", "single"],
-    "semi": ["error", "always"],
-    "class-methods-use-this": ["off"],
-    "no-underscore-dangle": [
+      "indent": ["error", 2],
+      "linebreak-style": 0,
+      "quotes": ["error", "single"],
+      "semi": ["error", "always"],
+      "class-methods-use-this": ["off"],
+      "no-underscore-dangle": [
       "error",
       {
-        "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]
+          "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]
       }
-    ],
-    "no-magic-numbers": [
+      ],
+      "no-magic-numbers": [
       "error",
       {
-        "ignore": [0, 1, 2, 100],
-        "ignoreArrayIndexes": true,
-        "enforceConst": true,
-        "detectObjects": false
+          "ignore": [0, 1, 2, 100],
+          "ignoreArrayIndexes": true,
+          "enforceConst": true,
+          "detectObjects": false
       }
-    ],
-    "react/button-has-type": ["off"],
-    "no-console": ["off"],
-    "no-param-reassign": ["off"],
-    "consistent-return": ["off"],
-    "no-undef": ["off"],
-    "max-len": [
+      ],
+      "react/button-has-type": ["off"],
+      "no-console": ["off"],
+      "no-param-reassign": ["off"],
+      "consistent-return": ["off"],
+      "no-undef": ["off"],
+      "max-len": [
       "error",
       {
-        "code": 90,
-        "ignoreComments": true,
-        "ignoreUrls": true,
-        "ignoreRegExpLiterals": true
+          "code": 90,
+          "ignoreComments": true,
+          "ignoreUrls": true,
+          "ignoreRegExpLiterals": true
       }
-    ],
-    "max-params": ["error", 4],
-    "max-lines": ["error", 250],
-    "complexity": ["error", 15],
-    "object-curly-newline": ["off"],
-    "import/no-extraneous-dependencies": ["off"],
-    "import/prefer-default-export": ["off"],
-    "react/jsx-filename-extension": [
+      ],
+      "max-params": ["error", 4],
+      "max-lines": ["error", 250],
+      "complexity": ["error", 15],
+      "object-curly-newline": ["off"],
+      "import/no-extraneous-dependencies": ["off"],
+      "import/prefer-default-export": ["off"],
+      "react/jsx-filename-extension": [
       1,
       {
-        "extensions": [".js", ".jsx"]
+          "extensions": [".js", ".jsx"]
       }
-    ],
-    "react/default-props-match-prop-types": [
+      ],
+      "react/default-props-match-prop-types": [
       "error",
       {
-        "allowRequiredDefaults": false
+          "allowRequiredDefaults": false
       }
-    ],
-    "react/require-default-props": [
+      ],
+      "react/require-default-props": [
       "error",
       {
-        "functions": "defaultArguments"
+          "functions": "defaultArguments"
       }
-    ],
-    "react/no-array-index-key": ["off"],
-    "react/destructuring-assignment": ["error", "always"],
-    "react/forbid-component-props": ["error"],
-    "react/forbid-prop-types": ["error"],
-    "react/jsx-props-no-spreading": ["off"],
-    "react/no-multi-comp": [
+      ],
+      "react/no-array-index-key": ["off"],
+      "react/destructuring-assignment": ["error", "always"],
+      "react/forbid-component-props": ["error"],
+      "react/forbid-prop-types": ["error"],
+      "react/jsx-props-no-spreading": ["off"],
+      "react/no-multi-comp": [
       "error",
       {
-        "ignoreStateless": false
+          "ignoreStateless": false
       }
-    ],
-    "react/prefer-stateless-function": ["off"],
-    "react/no-access-state-in-setstate": ["error"],
-    "react/no-redundant-should-component-update": ["error"],
-    "react/no-this-in-sfc": ["error"],
-    "react/no-typos": ["error"],
-    "react/no-unsafe": ["error"],
-    "react/no-unused-state": ["error"],
-    "react/no-will-update-set-state": ["error"],
-    "react/prefer-es6-class": ["error", "always"],
-    "react/self-closing-comp": ["error"],
-    "react/state-in-constructor": ["off"],
-    "react/void-dom-elements-no-children": ["error"],
-    "react/jsx-closing-bracket-location": ["error"],
-    "react/jsx-closing-tag-location": ["error"],
-    "react/jsx-curly-newline": ["error"],
-    "react/jsx-fragments": ["error"],
-    "react/jsx-max-depth": [
+      ],
+      "react/prefer-stateless-function": ["off"],
+      "react/no-access-state-in-setstate": ["error"],
+      "react/no-redundant-should-component-update": ["error"],
+      "react/no-this-in-sfc": ["error"],
+      "react/no-typos": ["error"],
+      "react/no-unsafe": ["error"],
+      "react/no-unused-state": ["error"],
+      "react/no-will-update-set-state": ["error"],
+      "react/prefer-es6-class": ["error", "always"],
+      "react/self-closing-comp": ["error"],
+      "react/state-in-constructor": ["off"],
+      "react/void-dom-elements-no-children": ["error"],
+      "react/jsx-closing-bracket-location": ["error"],
+      "react/jsx-closing-tag-location": ["error"],
+      "react/jsx-curly-newline": ["error"],
+      "react/jsx-fragments": ["error"],
+      "react/jsx-max-depth": [
       "error",
       {
-        "max": 4
+          "max": 4
       }
-    ],
-    "react/jsx-no-useless-fragment": ["error"],
-    "react/jsx-curly-spacing": [
+      ],
+      "react/jsx-no-useless-fragment": ["error"],
+      "react/jsx-curly-spacing": [
       "error",
       {
-        "when": "always"
+          "when": "always"
       }
-    ],
-    "react/jsx-equals-spacing": ["error", "never"],
-    "react/jsx-first-prop-new-line": ["error", "multiline"],
-    "react/jsx-indent": [
+      ],
+      "react/jsx-equals-spacing": ["error", "never"],
+      "react/jsx-first-prop-new-line": ["error", "multiline"],
+      "react/jsx-indent": [
       "error",
       2,
       {
-        "checkAttributes": true,
-        "indentLogicalExpressions": true
+          "checkAttributes": true,
+          "indentLogicalExpressions": true
       }
-    ],
-    "react/jsx-indent-props": ["error", 2],
-    "react/jsx-key": ["error"],
-    "react/jsx-max-props-per-line": [
+      ],
+      "react/jsx-indent-props": ["error", 2],
+      "react/jsx-key": ["error"],
+      "react/jsx-max-props-per-line": [
       "error",
       {
-        "maximum": 1,
-        "when": "multiline"
+          "maximum": 1,
+          "when": "multiline"
       }
-    ],
-    "react/jsx-tag-spacing": [
+      ],
+      "react/jsx-tag-spacing": [
       "error",
       {
-        "closingSlash": "never",
-        "beforeSelfClosing": "always",
-        "afterOpening": "never",
-        "beforeClosing": "never"
+          "closingSlash": "never",
+          "beforeSelfClosing": "always",
+          "afterOpening": "never",
+          "beforeClosing": "never"
       }
-    ],
-    "react/jsx-wrap-multilines": [
+      ],
+      "react/jsx-wrap-multilines": [
       "error",
       {
-        "declaration": "parens",
-        "assignment": "parens",
-        "return": "parens",
-        "arrow": "parens",
-        "condition": "ignore",
-        "logical": "ignore",
-        "prop": "ignore"
+          "declaration": "parens",
+          "assignment": "parens",
+          "return": "parens",
+          "arrow": "parens",
+          "condition": "ignore",
+          "logical": "ignore",
+          "prop": "ignore"
       }
-    ],
-    "react/react-in-jsx-scope": "off",
-    "default-param-last": "off",
-    "jsx-a11y/label-has-associated-control": [
+      ],
+      "react/react-in-jsx-scope": "off",
+      "default-param-last": "off",
+      "jsx-a11y/label-has-associated-control": [
       "error",
-      {
-        "assert": "either"
-      }
-    ],
-    "template-curly-spacing": ["error", "always"],
-    "template-tag-spacing": ["error", "always"],
-    "arrow-parens": ["error", "always"],
-    "arrow-spacing": ["error", { "before": true, "after": true }],
-    "no-confusing-arrow": ["error", { "allowParens": true }],
-    "no-duplicate-imports": ["error", { "includeExports": true }]
-  }
+    {
+      "assert": "either"
+    }
+  ],
+  "template-curly-spacing": ["error", "always"],
+  "template-tag-spacing": ["error", "always"],
+  "arrow-parens": ["error", "always"],
+  "arrow-spacing": ["error", { "before": true, "after": true }],
+  "no-confusing-arrow": ["error", { "allowParens": true }],
+  "no-duplicate-imports": ["error", { "includeExports": true }]
+}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -170,9 +170,9 @@
         "default-param-last": "off",
         "jsx-a11y/label-has-associated-control": [
         "error",
-    {
+      {
         "assert": "either"
-    }
+      }
     ],
     "template-curly-spacing": ["error", "always"],
     "template-tag-spacing": ["error", "always"],
@@ -180,5 +180,5 @@
     "arrow-spacing": ["error", { "before": true, "after": true }],
     "no-confusing-arrow": ["error", { "allowParens": true }],
     "no-duplicate-imports": ["error", { "includeExports": true }]
-}
+  }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,184 +1,184 @@
 {
-  "env": {
-      "browser": true,
-      "es2021": true
-  },
-  "extends": [
-      "plugin:react/recommended",
-      "airbnb",
-      "eslint:recommended"
-  ],
-  "overrides": [
-  ],
-  "parserOptions": {
-      "ecmaFeatures": {
-          "jsx": true
-      },
-      "ecmaVersion": "latest",
-      "sourceType": "module"
-  },
-  "settings": {
-    "import/resolver": {
-      "node": {
-        "extensions": [".js", ".jsx", ".ts", ".tsx"]
-      }
+    "env": {
+        "browser": true,
+        "es2021": true
+    },
+    "extends": [
+        "plugin:react/recommended",
+        "airbnb",
+        "eslint:recommended"
+    ],
+    "overrides": [
+    ],
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": "latest",
+        "sourceType": "module"
+    },
+    "settings": {
+        "import/resolver": {
+        "node": {
+            "extensions": [".js", ".jsx", ".ts", ".tsx"]
+        }
+        }
+    },
+    "plugins": [
+        "react"
+    ],
+    "rules": {
+        "indent": ["error", 2],
+        "linebreak-style": 0,
+        "quotes": ["error", "single"],
+        "semi": ["error", "always"],
+        "class-methods-use-this": ["off"],
+        "no-underscore-dangle": [
+        "error",
+        {
+            "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]
+        }
+        ],
+        "no-magic-numbers": [
+        "error",
+        {
+            "ignore": [0, 1, 2, 100],
+            "ignoreArrayIndexes": true,
+            "enforceConst": true,
+            "detectObjects": false
+        }
+        ],
+        "react/button-has-type": ["off"],
+        "no-console": ["off"],
+        "no-param-reassign": ["off"],
+        "consistent-return": ["off"],
+        "no-undef": ["off"],
+        "max-len": [
+        "error",
+        {
+            "code": 90,
+            "ignoreComments": true,
+            "ignoreUrls": true,
+            "ignoreRegExpLiterals": true
+        }
+        ],
+        "max-params": ["error", 4],
+        "max-lines": ["error", 250],
+        "complexity": ["error", 15],
+        "object-curly-newline": ["off"],
+        "import/no-extraneous-dependencies": ["off"],
+        "import/prefer-default-export": ["off"],
+        "react/jsx-filename-extension": [
+        1,
+        {
+            "extensions": [".js", ".jsx"]
+        }
+        ],
+        "react/default-props-match-prop-types": [
+        "error",
+        {
+            "allowRequiredDefaults": false
+        }
+        ],
+        "react/require-default-props": [
+        "error",
+        {
+            "functions": "defaultArguments"
+        }
+        ],
+        "react/no-array-index-key": ["off"],
+        "react/destructuring-assignment": ["error", "always"],
+        "react/forbid-component-props": ["error"],
+        "react/forbid-prop-types": ["error"],
+        "react/jsx-props-no-spreading": ["off"],
+        "react/no-multi-comp": [
+        "error",
+        {
+            "ignoreStateless": false
+        }
+        ],
+        "react/prefer-stateless-function": ["off"],
+        "react/no-access-state-in-setstate": ["error"],
+        "react/no-redundant-should-component-update": ["error"],
+        "react/no-this-in-sfc": ["error"],
+        "react/no-typos": ["error"],
+        "react/no-unsafe": ["error"],
+        "react/no-unused-state": ["error"],
+        "react/no-will-update-set-state": ["error"],
+        "react/prefer-es6-class": ["error", "always"],
+        "react/self-closing-comp": ["error"],
+        "react/state-in-constructor": ["off"],
+        "react/void-dom-elements-no-children": ["error"],
+        "react/jsx-closing-bracket-location": ["error"],
+        "react/jsx-closing-tag-location": ["error"],
+        "react/jsx-curly-newline": ["error"],
+        "react/jsx-fragments": ["error"],
+        "react/jsx-max-depth": [
+        "error",
+        {
+            "max": 4
+        }
+        ],
+        "react/jsx-no-useless-fragment": ["error"],
+        "react/jsx-curly-spacing": [
+        "error",
+        {
+            "when": "always"
+        }
+        ],
+        "react/jsx-equals-spacing": ["error", "never"],
+        "react/jsx-first-prop-new-line": ["error", "multiline"],
+        "react/jsx-indent": [
+        "error",
+        2,
+        {
+            "checkAttributes": true,
+            "indentLogicalExpressions": true
+        }
+        ],
+        "react/jsx-indent-props": ["error", 2],
+        "react/jsx-key": ["error"],
+        "react/jsx-max-props-per-line": [
+        "error",
+        {
+            "maximum": 1,
+            "when": "multiline"
+        }
+        ],
+        "react/jsx-tag-spacing": [
+        "error",
+        {
+            "closingSlash": "never",
+            "beforeSelfClosing": "always",
+            "afterOpening": "never",
+            "beforeClosing": "never"
+        }
+        ],
+        "react/jsx-wrap-multilines": [
+        "error",
+        {
+            "declaration": "parens",
+            "assignment": "parens",
+            "return": "parens",
+            "arrow": "parens",
+            "condition": "ignore",
+            "logical": "ignore",
+            "prop": "ignore"
+        }
+        ],
+        "react/react-in-jsx-scope": "off",
+        "default-param-last": "off",
+        "jsx-a11y/label-has-associated-control": [
+        "error",
+        {
+        "assert": "either"
+        }
+    ],
+    "template-curly-spacing": ["error", "always"],
+    "template-tag-spacing": ["error", "always"],
+    "arrow-parens": ["error", "always"],
+    "arrow-spacing": ["error", { "before": true, "after": true }],
+    "no-confusing-arrow": ["error", { "allowParens": true }],
+    "no-duplicate-imports": ["error", { "includeExports": true }]
     }
-  },
-  "plugins": [
-      "react"
-  ],
-  "rules": {
-      "indent": ["error", 2],
-      "linebreak-style": 0,
-      "quotes": ["error", "single"],
-      "semi": ["error", "always"],
-      "class-methods-use-this": ["off"],
-      "no-underscore-dangle": [
-      "error",
-      {
-          "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]
-      }
-      ],
-      "no-magic-numbers": [
-      "error",
-      {
-          "ignore": [0, 1, 2, 100],
-          "ignoreArrayIndexes": true,
-          "enforceConst": true,
-          "detectObjects": false
-      }
-      ],
-      "react/button-has-type": ["off"],
-      "no-console": ["off"],
-      "no-param-reassign": ["off"],
-      "consistent-return": ["off"],
-      "no-undef": ["off"],
-      "max-len": [
-      "error",
-      {
-          "code": 90,
-          "ignoreComments": true,
-          "ignoreUrls": true,
-          "ignoreRegExpLiterals": true
-      }
-      ],
-      "max-params": ["error", 4],
-      "max-lines": ["error", 250],
-      "complexity": ["error", 15],
-      "object-curly-newline": ["off"],
-      "import/no-extraneous-dependencies": ["off"],
-      "import/prefer-default-export": ["off"],
-      "react/jsx-filename-extension": [
-      1,
-      {
-          "extensions": [".js", ".jsx"]
-      }
-      ],
-      "react/default-props-match-prop-types": [
-      "error",
-      {
-          "allowRequiredDefaults": false
-      }
-      ],
-      "react/require-default-props": [
-      "error",
-      {
-          "functions": "defaultArguments"
-      }
-      ],
-      "react/no-array-index-key": ["off"],
-      "react/destructuring-assignment": ["error", "always"],
-      "react/forbid-component-props": ["error"],
-      "react/forbid-prop-types": ["error"],
-      "react/jsx-props-no-spreading": ["off"],
-      "react/no-multi-comp": [
-      "error",
-      {
-          "ignoreStateless": false
-      }
-      ],
-      "react/prefer-stateless-function": ["off"],
-      "react/no-access-state-in-setstate": ["error"],
-      "react/no-redundant-should-component-update": ["error"],
-      "react/no-this-in-sfc": ["error"],
-      "react/no-typos": ["error"],
-      "react/no-unsafe": ["error"],
-      "react/no-unused-state": ["error"],
-      "react/no-will-update-set-state": ["error"],
-      "react/prefer-es6-class": ["error", "always"],
-      "react/self-closing-comp": ["error"],
-      "react/state-in-constructor": ["off"],
-      "react/void-dom-elements-no-children": ["error"],
-      "react/jsx-closing-bracket-location": ["error"],
-      "react/jsx-closing-tag-location": ["error"],
-      "react/jsx-curly-newline": ["error"],
-      "react/jsx-fragments": ["error"],
-      "react/jsx-max-depth": [
-      "error",
-      {
-          "max": 4
-      }
-      ],
-      "react/jsx-no-useless-fragment": ["error"],
-      "react/jsx-curly-spacing": [
-      "error",
-      {
-          "when": "always"
-      }
-      ],
-      "react/jsx-equals-spacing": ["error", "never"],
-      "react/jsx-first-prop-new-line": ["error", "multiline"],
-      "react/jsx-indent": [
-      "error",
-      2,
-      {
-          "checkAttributes": true,
-          "indentLogicalExpressions": true
-      }
-      ],
-      "react/jsx-indent-props": ["error", 2],
-      "react/jsx-key": ["error"],
-      "react/jsx-max-props-per-line": [
-      "error",
-      {
-          "maximum": 1,
-          "when": "multiline"
-      }
-      ],
-      "react/jsx-tag-spacing": [
-      "error",
-      {
-          "closingSlash": "never",
-          "beforeSelfClosing": "always",
-          "afterOpening": "never",
-          "beforeClosing": "never"
-      }
-      ],
-      "react/jsx-wrap-multilines": [
-      "error",
-      {
-          "declaration": "parens",
-          "assignment": "parens",
-          "return": "parens",
-          "arrow": "parens",
-          "condition": "ignore",
-          "logical": "ignore",
-          "prop": "ignore"
-      }
-      ],
-      "react/react-in-jsx-scope": "off",
-      "default-param-last": "off",
-      "jsx-a11y/label-has-associated-control": [
-      "error",
-    {
-      "assert": "either"
-    }
-  ],
-  "template-curly-spacing": ["error", "always"],
-  "template-tag-spacing": ["error", "always"],
-  "arrow-parens": ["error", "always"],
-  "arrow-spacing": ["error", { "before": true, "after": true }],
-  "no-confusing-arrow": ["error", { "allowParens": true }],
-  "no-duplicate-imports": ["error", { "includeExports": true }]
-}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,168 +1,168 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["plugin:react/recommended", "airbnb", "eslint:recommended"],
+  "overrides": [],
+  "parserOptions": {
+    "ecmaFeatures": {
+      "jsx": true
     },
-    "extends": [
-        "plugin:react/recommended",
-        "airbnb",
-        "eslint:recommended"
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+      }
+    }
+  },
+  "plugins": ["react"],
+  "rules": {
+    "indent": ["error", 2],
+    "linebreak-style": 0,
+    "quotes": ["error", "single"],
+    "semi": ["error", "always"],
+    "class-methods-use-this": ["off"],
+    "no-underscore-dangle": [
+      "error",
+      {
+        "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]
+      }
     ],
-    "overrides": [
+    "no-magic-numbers": [
+      "error",
+      {
+        "ignore": [0, 1, 2, 100],
+        "ignoreArrayIndexes": true,
+        "enforceConst": true,
+        "detectObjects": false
+      }
     ],
-    "parserOptions": {
-        "ecmaFeatures": {
-            "jsx": true
-        },
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react"
+    "react/button-has-type": ["off"],
+    "no-console": ["off"],
+    "no-param-reassign": ["off"],
+    "consistent-return": ["off"],
+    "no-undef": ["off"],
+    "max-len": [
+      "error",
+      {
+        "code": 90,
+        "ignoreComments": true,
+        "ignoreUrls": true,
+        "ignoreRegExpLiterals": true
+      }
     ],
-    "rules": {
-        "indent": ["error", 2],
-        "linebreak-style": 0,
-        "quotes": ["error", "single"],
-        "semi": ["error", "always"],
-        "class-methods-use-this": ["off"],
-        "no-underscore-dangle": [
-        "error",
-        {
-            "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"]
-        }
-        ],
-        "no-magic-numbers": [
-        "error",
-        {
-            "ignore": [0, 1, 2, 100],
-            "ignoreArrayIndexes": true,
-            "enforceConst": true,
-            "detectObjects": false
-        }
-        ],
-        "react/button-has-type": ["off"],
-        "no-console": ["off"],
-        "no-param-reassign": ["off"],
-        "consistent-return": ["off"],
-        "no-undef": ["off"],
-        "max-len": [
-        "error",
-        {
-            "code": 90,
-            "ignoreComments": true,
-            "ignoreUrls": true,
-            "ignoreRegExpLiterals": true
-        }
-        ],
-        "max-params": ["error", 4],
-        "max-lines": ["error", 250],
-        "complexity": ["error", 15],
-        "object-curly-newline": ["off"],
-        "import/no-extraneous-dependencies": ["off"],
-        "import/prefer-default-export": ["off"],
-        "react/jsx-filename-extension": [
-        1,
-        {
-            "extensions": [".js", ".jsx"]
-        }
-        ],
-        "react/default-props-match-prop-types": [
-        "error",
-        {
-            "allowRequiredDefaults": false
-        }
-        ],
-        "react/require-default-props": [
-        "error",
-        {
-            "functions": "defaultArguments"
-        }
-        ],
-        "react/no-array-index-key": ["off"],
-        "react/destructuring-assignment": ["error", "always"],
-        "react/forbid-component-props": ["error"],
-        "react/forbid-prop-types": ["error"],
-        "react/jsx-props-no-spreading": ["off"],
-        "react/no-multi-comp": [
-        "error",
-        {
-            "ignoreStateless": false
-        }
-        ],
-        "react/prefer-stateless-function": ["off"],
-        "react/no-access-state-in-setstate": ["error"],
-        "react/no-redundant-should-component-update": ["error"],
-        "react/no-this-in-sfc": ["error"],
-        "react/no-typos": ["error"],
-        "react/no-unsafe": ["error"],
-        "react/no-unused-state": ["error"],
-        "react/no-will-update-set-state": ["error"],
-        "react/prefer-es6-class": ["error", "always"],
-        "react/self-closing-comp": ["error"],
-        "react/state-in-constructor": ["off"],
-        "react/void-dom-elements-no-children": ["error"],
-        "react/jsx-closing-bracket-location": ["error"],
-        "react/jsx-closing-tag-location": ["error"],
-        "react/jsx-curly-newline": ["error"],
-        "react/jsx-fragments": ["error"],
-        "react/jsx-max-depth": [
-        "error",
-        {
-            "max": 4
-        }
-        ],
-        "react/jsx-no-useless-fragment": ["error"],
-        "react/jsx-curly-spacing": [
-        "error",
-        {
-            "when": "always"
-        }
-        ],
-        "react/jsx-equals-spacing": ["error", "never"],
-        "react/jsx-first-prop-new-line": ["error", "multiline"],
-        "react/jsx-indent": [
-        "error",
-        2,
-        {
-            "checkAttributes": true,
-            "indentLogicalExpressions": true
-        }
-        ],
-        "react/jsx-indent-props": ["error", 2],
-        "react/jsx-key": ["error"],
-        "react/jsx-max-props-per-line": [
-        "error",
-        {
-            "maximum": 1,
-            "when": "multiline"
-        }
-        ],
-        "react/jsx-tag-spacing": [
-        "error",
-        {
-            "closingSlash": "never",
-            "beforeSelfClosing": "always",
-            "afterOpening": "never",
-            "beforeClosing": "never"
-        }
-        ],
-        "react/jsx-wrap-multilines": [
-        "error",
-        {
-            "declaration": "parens",
-            "assignment": "parens",
-            "return": "parens",
-            "arrow": "parens",
-            "condition": "ignore",
-            "logical": "ignore",
-            "prop": "ignore"
-        }
-        ],
-        "react/react-in-jsx-scope": "off",
-        "default-param-last": "off",
-        "jsx-a11y/label-has-associated-control": [
-        "error",
+    "max-params": ["error", 4],
+    "max-lines": ["error", 250],
+    "complexity": ["error", 15],
+    "object-curly-newline": ["off"],
+    "import/no-extraneous-dependencies": ["off"],
+    "import/prefer-default-export": ["off"],
+    "react/jsx-filename-extension": [
+      1,
+      {
+        "extensions": [".js", ".jsx"]
+      }
+    ],
+    "react/default-props-match-prop-types": [
+      "error",
+      {
+        "allowRequiredDefaults": false
+      }
+    ],
+    "react/require-default-props": [
+      "error",
+      {
+        "functions": "defaultArguments"
+      }
+    ],
+    "react/no-array-index-key": ["off"],
+    "react/destructuring-assignment": ["error", "always"],
+    "react/forbid-component-props": ["error"],
+    "react/forbid-prop-types": ["error"],
+    "react/jsx-props-no-spreading": ["off"],
+    "react/no-multi-comp": [
+      "error",
+      {
+        "ignoreStateless": false
+      }
+    ],
+    "react/prefer-stateless-function": ["off"],
+    "react/no-access-state-in-setstate": ["error"],
+    "react/no-redundant-should-component-update": ["error"],
+    "react/no-this-in-sfc": ["error"],
+    "react/no-typos": ["error"],
+    "react/no-unsafe": ["error"],
+    "react/no-unused-state": ["error"],
+    "react/no-will-update-set-state": ["error"],
+    "react/prefer-es6-class": ["error", "always"],
+    "react/self-closing-comp": ["error"],
+    "react/state-in-constructor": ["off"],
+    "react/void-dom-elements-no-children": ["error"],
+    "react/jsx-closing-bracket-location": ["error"],
+    "react/jsx-closing-tag-location": ["error"],
+    "react/jsx-curly-newline": ["error"],
+    "react/jsx-fragments": ["error"],
+    "react/jsx-max-depth": [
+      "error",
+      {
+        "max": 4
+      }
+    ],
+    "react/jsx-no-useless-fragment": ["error"],
+    "react/jsx-curly-spacing": [
+      "error",
+      {
+        "when": "always"
+      }
+    ],
+    "react/jsx-equals-spacing": ["error", "never"],
+    "react/jsx-first-prop-new-line": ["error", "multiline"],
+    "react/jsx-indent": [
+      "error",
+      2,
+      {
+        "checkAttributes": true,
+        "indentLogicalExpressions": true
+      }
+    ],
+    "react/jsx-indent-props": ["error", 2],
+    "react/jsx-key": ["error"],
+    "react/jsx-max-props-per-line": [
+      "error",
+      {
+        "maximum": 1,
+        "when": "multiline"
+      }
+    ],
+    "react/jsx-tag-spacing": [
+      "error",
+      {
+        "closingSlash": "never",
+        "beforeSelfClosing": "always",
+        "afterOpening": "never",
+        "beforeClosing": "never"
+      }
+    ],
+    "react/jsx-wrap-multilines": [
+      "error",
+      {
+        "declaration": "parens",
+        "assignment": "parens",
+        "return": "parens",
+        "arrow": "parens",
+        "condition": "ignore",
+        "logical": "ignore",
+        "prop": "ignore"
+      }
+    ],
+    "react/react-in-jsx-scope": "off",
+    "default-param-last": "off",
+    "jsx-a11y/label-has-associated-control": [
+      "error",
       {
         "assert": "either"
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -170,9 +170,9 @@
         "default-param-last": "off",
         "jsx-a11y/label-has-associated-control": [
         "error",
-        {
+    {
         "assert": "either"
-        }
+    }
     ],
     "template-curly-spacing": ["error", "always"],
     "template-tag-spacing": ["error", "always"],
@@ -180,5 +180,5 @@
     "arrow-spacing": ["error", { "before": true, "after": true }],
     "no-confusing-arrow": ["error", { "allowParens": true }],
     "no-duplicate-imports": ["error", { "includeExports": true }]
-    }
+}
 }

--- a/src/templates/cadastro/CadastroTemplate.jsx
+++ b/src/templates/cadastro/CadastroTemplate.jsx
@@ -1,15 +1,21 @@
-import React from 'react';
-import CadastroPrimeiraTela from './components/CadastroPrimeiraTela';
+import React, { useState } from 'react';
 import HeaderCadastro from './components/HeaderCadastro';
+import CadastroPrimeiraTela from './components/CadastroPrimeiraTela';
+import CadastroTerceiraTela from './components/CadastroTerceiraTela';
 
 export default function cadastroTemplate() {
-  const [controller, setController] = React.useState(0);
+  const [controller, setController] = useState(0);
 
   return (
     <>
       <HeaderCadastro />
-      {controller === 0 && <CadastroPrimeiraTela setController={ setController } /> }
-
+      {controller === 0 && (
+        <CadastroPrimeiraTela setController={ setController } />
+      )}
+      {/* Vamos adaptando conforme as páginas chegam */}
+      {controller === 1 && (
+        <CadastroTerceiraTela setController={ setController } />
+      )}
     </>
   );
 }

--- a/src/templates/cadastro/CadastroTemplate.jsx
+++ b/src/templates/cadastro/CadastroTemplate.jsx
@@ -9,9 +9,9 @@ export default function cadastroTemplate() {
   return (
     <>
       <HeaderCadastro />
-      {controller === 0 && (<CadastroPrimeiraTela setController={ setController } />)}
+      {controller === 0 && <CadastroPrimeiraTela setController={ setController } />}
       {/* Vamos adaptando conforme as páginas chegam */}
-      {controller === 1 && (<CadastroTerceiraTela setController={ setController } />)}
+      {controller === 1 && <CadastroTerceiraTela setController={ setController } />}
     </>
   );
 }

--- a/src/templates/cadastro/CadastroTemplate.jsx
+++ b/src/templates/cadastro/CadastroTemplate.jsx
@@ -9,13 +9,9 @@ export default function cadastroTemplate() {
   return (
     <>
       <HeaderCadastro />
-      {controller === 0 && (
-        <CadastroPrimeiraTela setController={ setController } />
-      )}
+      {controller === 0 && (<CadastroPrimeiraTela setController={ setController } />)}
       {/* Vamos adaptando conforme as páginas chegam */}
-      {controller === 1 && (
-        <CadastroTerceiraTela setController={ setController } />
-      )}
+      {controller === 1 && (<CadastroTerceiraTela setController={ setController } />)}
     </>
   );
 }

--- a/src/templates/cadastro/components/CadastroTerceiraTela.jsx
+++ b/src/templates/cadastro/components/CadastroTerceiraTela.jsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useForm } from 'react-hook-form';
+import { useDispatch } from 'react-redux';
+
+import { AWARENESS, OPEN_TEXT_FIELDS, REFERRAL } from './constants';
+
+import styles from '../styles/CadastroPrimeiraTela.module.css';
+
+import { cadastroTela3Schema } from './schemas';
+
+export default function cadastroTerceiraTela(props) {
+  const [about, experience, expectations] = OPEN_TEXT_FIELDS;
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm({
+    resolver: yupResolver(cadastroTela3Schema),
+  });
+
+  const dispatch = useDispatch();
+  const { setController } = props;
+
+  watch('referral');
+  watch('awareness');
+  watch('aboutYou');
+  watch('experience');
+  watch('expectations');
+
+  const onSubmit = (data) => {
+    console.log(data);
+    dispatch(increment());
+    reset();
+  };
+
+  const adjustTextAreaSize = (e) => {
+    e.target.style.height = 'inherit';
+    e.target.style.height = `${ e.target.scrollHeight }px`;
+  };
+
+  return (
+    <form
+      className={ styles.cadastroFormSection }
+      onSubmit={ handleSubmit(onSubmit) }
+    >
+      <section>
+        <div className={ styles.cadastroFormDiv }>
+          <label className={ styles.formParagraph } htmlFor={ REFERRAL.fieldLabel }>
+            {REFERRAL.fieldLabel}
+          </label>
+          <select
+            defaultValue=""
+            className={ styles.cadastroFormSectionInputText }
+            { ...register('referral') }
+          >
+            <option value="" hidden disabled>
+              Selecione
+            </option>
+            {REFERRAL.options.map((option) => (
+              <option key={ option } value={ option }>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className={ styles.cadastroFormDiv }>
+          <label
+            className={ styles.formParagraph }
+            htmlFor={ AWARENESS.fieldLabel }
+          >
+            {AWARENESS.fieldLabel}
+          </label>
+          <select
+            defaultValue=""
+            className={ styles.cadastroFormSectionInputText }
+            { ...register('awareness') }
+          >
+            <option value="" hidden disabled>
+              Selecione
+            </option>
+            {AWARENESS.options.map(({ label, value }) => (
+              <option key={ value } value={ value }>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className={ styles.cadastroFormDiv }>
+          <label className={ styles.formParagraph } htmlFor={ about.label }>
+            {about.text}
+          </label>
+          <textarea
+            className={ styles.cadastroFormSectionInputText }
+            onKeyDown={ adjustTextAreaSize }
+            { ...register('aboutYou') }
+          />
+          {errors.aboutYou && (
+            <p className={ styles.inputError }>{errors.aboutYou.message}</p>
+          )}
+        </div>
+        <div className={ styles.cadastroFormDiv }>
+          <label className={ styles.formParagraph } htmlFor={ experience.label }>
+            {experience.text}
+          </label>
+          <textarea
+            className={ styles.cadastroFormSectionInputText }
+            onKeyDown={ adjustTextAreaSize }
+            { ...register('experience') }
+          />
+          {errors.experience && (
+            <p className={ styles.inputError }>{errors.experience.message}</p>
+          )}
+        </div>
+        <div className={ styles.cadastroFormDiv }>
+          <label className={ styles.formParagraph } htmlFor={ expectations.label }>
+            {expectations.text}
+          </label>
+          <textarea
+            className={ styles.cadastroFormSectionInputText }
+            onKeyDown={ adjustTextAreaSize }
+            { ...register('expectations') }
+          />
+          {errors.expectations && (
+            <p className={ styles.inputError }>{errors.expectations.message}</p>
+          )}
+        </div>
+      </section>
+
+      <button
+        type="submit"
+        className={ styles.cadastroFormSectionButton }
+        onClick={ () => setController(0) } // Por agora, enquanto não temos as seguintes.
+      >
+        Próximo
+      </button>
+    </form>
+  );
+}

--- a/src/templates/cadastro/components/constants.js
+++ b/src/templates/cadastro/components/constants.js
@@ -1,0 +1,49 @@
+export const REFERRAL = {
+  fieldLabel: 'Por onde você nos conheceu?',
+  options: [
+    'Atados',
+    'Instagram',
+    'Facebook',
+    'Linkedin',
+    'Pepsico',
+    'Youtube',
+    'Website',
+    'Indicações',
+    'Outros',
+  ],
+};
+
+export const AWARENESS = {
+  fieldLabel: 'Você conhece o programa de educação para a paz?',
+  options: [
+    {
+      label: 'Já participei dos 10 workshops',
+      value: 'complete',
+    },
+    { label: 'Já participei de alguns workshops', value: 'partial' },
+    {
+      label: 'Ainda não participei de nenhum',
+      value: 'none',
+    },
+  ],
+};
+
+export const OPEN_TEXT_FIELDS = [
+  {
+    label: 'aboutYou',
+    text: `Para entender melhor você como voluntário,
+    você poderia contar um pouco sobre seus conhecimentos e estudos?`,
+  },
+  {
+    label: 'experience',
+    text: `Você poderia compartilhar um pouco suas experiências? 
+    (Qualquer experiência é relevante, queremos te conhecer)`,
+  },
+  {
+    label: 'expectations',
+    text: `Quais são seus sonhos/desejos e como acha que se alinha 
+    com o nosso trabalho voluntário?`,
+  },
+];
+
+export const MANDATORY_FIELD = 'Este campo é obrigatório';

--- a/src/templates/cadastro/components/schemas.js
+++ b/src/templates/cadastro/components/schemas.js
@@ -1,0 +1,10 @@
+import * as yup from 'yup';
+import { MANDATORY_FIELD } from './constants';
+
+export const cadastroTela3Schema = yup.object().shape({
+  referral: yup.string(),
+  awareness: yup.string(),
+  aboutYou: yup.string().required(MANDATORY_FIELD),
+  experience: yup.string().required(MANDATORY_FIELD),
+  expectations: yup.string().required(MANDATORY_FIELD),
+});


### PR DESCRIPTION
## Resumo

Adiciona a terceira página do cadastro, após a primeira. Feito a partir do PR da primeira página e layout (https://github.com/PalavrasDePaz/palavras-de-paz-web/pull/11), então ainda sem a segunda e a quarta páginas.

Por algum motivo a validação do form não me estava funcionando. Eu basicamente copiei a lógica da primeira página, para manter uniforme, mas não consegui resolver. Podemos verificar tudo de uma vez, quando tudo estiver lá.

Também está faltando aquele banner de progresso, que acho que fica mais fácil fazer quando tivermos tudo.

Por agora, o botão de Submit volta para a tela inicial do cadastro, porque não tem para onde progredir no momento.

## Preview:

![image](https://user-images.githubusercontent.com/25609447/233473746-d7deefc8-e743-42fd-9d28-cdb2b90cb97d.png)

## Como testar

http://localhost:3000/cadastro, clicando em "Próximo" na primeira tela você chega lá.