### PR TITLE
Ajusta CSS da página de cadastro

### DIFF
--- a/src/templates/cadastro/components/CadastroTerceiraTela.jsx
+++ b/src/templates/cadastro/components/CadastroTerceiraTela.jsx
@@ -46,7 +46,7 @@ export default function cadastroTerceiraTela() {
       className={ styles.cadastroFormSection }
       onSubmit={ handleSubmit(onSubmit) }
     >
-      <section>
+      <section className={ styles.cadastroFormSectionInputContainer }>
         <div className={ styles.cadastroFormDiv }>
           <label className={ styles.formParagraph } htmlFor={ REFERRAL.fieldLabel }>
             {REFERRAL.fieldLabel}
@@ -88,6 +88,8 @@ export default function cadastroTerceiraTela() {
             ))}
           </select>
         </div>
+      </section>
+      <section>
         <div className={ styles.cadastroFormDiv }>
           <label className={ styles.formParagraph } htmlFor={ about.label }>
             {about.text}

--- a/src/templates/cadastro/components/Signature.jsx
+++ b/src/templates/cadastro/components/Signature.jsx
@@ -5,19 +5,21 @@ import styles from '../styles/Signature.module.css';
 export default function Signature({ controller }) {
   function createSignature(controllerNumber) {
     const signatureClass = `signature_${ controllerNumber }`;
+
+    const classNames = `${ styles.signatures } ${ styles[signatureClass] }`;
+
     return (
       <>
-        <div className={ styles[signatureClass] } />
-        <div className={ styles[signatureClass] } />
-
-        <div className={ styles[signatureClass] } />
+        <div className={ classNames } />
+        <div className={ classNames } />
+        <div className={ classNames } />
       </>
     );
   }
 
   return (
     <div className={ styles.signatures_container }>
-      { createSignature(controller)}
+      {createSignature(controller)}
     </div>
   );
 }

--- a/src/templates/cadastro/styles/CadastroTelas.module.css
+++ b/src/templates/cadastro/styles/CadastroTelas.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   max-width: calc(100% - 2rem);
-  margin: auto;
+  margin: 0 0.5rem;
 }
 
 .cadastroFormSectionInputContainer {

--- a/src/templates/cadastro/styles/CadastroTemplate.module.css
+++ b/src/templates/cadastro/styles/CadastroTemplate.module.css
@@ -9,7 +9,6 @@
 @media (min-width: 768px) {
   .main_container_form {
     max-width: 70rem;
-    align-items: end;
   }
 }
 
@@ -37,5 +36,11 @@
   .cadastroFormSectionButton {
     margin-right: 1rem;
     width: 10rem;
+    margin-left: auto;
   }
+}
+
+.main_container_button {
+  display: flex;
+  margin-right: 0.5rem;
 }

--- a/src/templates/cadastro/styles/Signature.module.css
+++ b/src/templates/cadastro/styles/Signature.module.css
@@ -1,49 +1,21 @@
 .signatures_container {
-    text-align: center;
-    margin-block: 2rem;
+  text-align: center;
+  margin-block: 2rem;
 }
 
-.signature_0 {
-    border: 1px solid #000;
-    border-radius: 5px;
-    padding: 5px;
-    margin: 5px;
-    width: 300px;
-    
-    display: inline-block;
-    vertical-align: center;
+.signatures {
+  border: 1px solid #d8d8d8;
+  border-radius: 5px;
+  padding: 5px;
+  margin: 5px;
+  width: 300px;
+
+  display: inline-block;
+  vertical-align: center;
 }
 
-.signature_0:first-child {
-    background-color: #18AC99;
-}
-
-.signature_1 {
-    border: 1px solid #000;
-    border-radius: 5px;
-    padding: 5px;
-    margin: 5px;
-    width: 300px;
-    
-    display: inline-block;
-    vertical-align: center;
-}
-
-.signature_1:nth-child(2) {
-    background-color: #18AC99;
-}
-
-.signature_2 {
-    border: 1px solid #000;
-    border-radius: 5px;
-    padding: 5px;
-    margin: 5px;
-    width: 300px;
-    
-    display: inline-block;
-    vertical-align: center;
-}
-
+.signature_0:first-child,
+.signature_1:nth-child(2),
 .signature_2:nth-child(3) {
-    background-color: #18AC99;
+  background-color: #18ac99;
 }

--- a/src/templates/cadastro/styles/Signature.module.css
+++ b/src/templates/cadastro/styles/Signature.module.css
@@ -8,7 +8,7 @@
   border-radius: 5px;
   padding: 5px;
   margin: 5px;
-  width: 300px;
+  width: 27%;
 
   display: inline-block;
   vertical-align: center;


### PR DESCRIPTION
Com base nas páginas 1 e 3 do cadastro, ajusta o css para que a barra superior, os campos e o botão de prosseguir fiquem relativamente alinhados.