### PR TITLE
feat: lógica para o botão logout da area de trabalho

### DIFF
--- a/src/templates/areaDeTrabalho/components/HeaderAreaDeTrabalho.jsx
+++ b/src/templates/areaDeTrabalho/components/HeaderAreaDeTrabalho.jsx
@@ -27,12 +27,24 @@ const HeaderAreaDeTrabalho = () => {
     setIsModalOpen(false);
   };
 
-  const logOut = () => {
+  const delayToRender = () => {
+    const promise = new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+
+    return promise;
+  };
+
+  const logOut = async () => {
     localStorage.removeItem(PALAVRAS_DE_PAZ_TOKEN);
     localStorage.removeItem("AUTH");
 
     queryClient.setQueryData(["user"], null);
     queryClient.invalidateQueries("user");
+
+    // Aguardar um curto período antes de redirecionar para garantir que a transição anterior seja concluída
+    await delayToRender();
+
     router.push("/");
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,7 +236,7 @@
   "resolved" "https://registry.npmjs.org/@next/env/-/env-12.3.4.tgz"
   "version" "12.3.4"
 
-"@next/swc-win32-x64-msvc@12.3.4":
+"@next/eslint-plugin-next@13.4.5":
   "integrity" "sha512-/xD/kyJhXmBZq+0xGKOdjL22c9/4i3mBAXaU9aOGEHTXqqFeOz8scJbScWF13aMqigeoFCsDqngIB2MIatcn4g=="
   "resolved" "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.4.5.tgz"
   "version" "13.4.5"


### PR DESCRIPTION
O comportamento que estava sendo observando era devido ao fato de que estavamos chamando router.push("/") no logOut e, em seguida, clicando no botão Image com onClick. Isso podia esta causando um comportamento estranho, pois a aplicação estava tentando navegar enquanto a navegação anterior ainda está em andamento. 

Uma solução que consegui foi adicionar um setTimeout para atrasar a chamada de router.push("/"), garantindo que a transição anterior seja concluída antes de iniciar uma nova.