### PR TITLE
feat: agora é possível atualizar senha e email

### DIFF
--- a/src/templates/areaDeTrabalho/components/Pagina-de-perfil.tsx
+++ b/src/templates/areaDeTrabalho/components/Pagina-de-perfil.tsx
@@ -62,6 +62,14 @@ const PerfilComponent = () => {
         country: data.country,
       },
     };
+
+    if (data.new_email && data.new_email !== "") {
+      updateData.data.email = data.new_email;
+    }
+    if (data.new_password && data.new_password !== "") {
+      updateData.data.password = data.new_password;
+    }
+
     updateUser(updateData);
     setUpdateSuccess(true);
   };


### PR DESCRIPTION
Testado na local foi possivel atualizar e-mail e senha separados.
Bem como os campos do formulário sem enviar senha e/ou email vazio para o banco.